### PR TITLE
Fix Obsolete warning on Unity 2017.3+

### DIFF
--- a/View/Inspector/BuildVariantInspector.cs
+++ b/View/Inspector/BuildVariantInspector.cs
@@ -124,7 +124,7 @@ namespace BuildVariants.View.Inspector {
 
             EditorGUILayout.Space();
             inspectedBuildVariant.BuildOptions =
-                (BuildOptions) EditorGUILayout.EnumMaskPopup("Build options:", inspectedBuildVariant.BuildOptions);
+                (BuildOptions) EditorGUILayout.EnumFlagsField("Build options:", inspectedBuildVariant.BuildOptions);
             
             EditorGUILayout.Space();
             DrawFilesList(inspectedBuildVariant, inspectedBuildVariant.MoveFiles);


### PR DESCRIPTION
I don't know, what exactly Unity version you are using, but 2017.3 is oldest non-legacy so that change can be useful to keep project warnings-clean.